### PR TITLE
Pin in Led::init() should be off before setting pin direction

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -239,8 +239,8 @@ namespace leds {
             pin_toggle::set();   // Set PTOR to 1.
         };
         inline static void init() {
-            pin_direction::write(pin_output_dir);
             off();
+            pin_direction::write(pin_output_dir);
         };
 
     }


### PR DESCRIPTION
Super minor, but I figured it might be good to have that looking correct in the getting started guide.